### PR TITLE
Fix typo

### DIFF
--- a/test/carbon-dating.test.js
+++ b/test/carbon-dating.test.js
@@ -52,7 +52,7 @@ describe('Carbon dating', () => {
       assert.equal(dateSample('3.142'), 12926);
       assert.equal(dateSample('1.1'), 21604);
       assert.equal(dateSample('9.8888'), 3446);
-      assert.equal(dateSample('11.3231.3213124'), 2326);
+      assert.equal(dateSample('11.32313213124'), 2326);
       assert.equal(dateSample('9.59383373526808'), 3696);
       assert.equal(dateSample('9.122605776326203'), 4112);
       assert.equal(dateSample('8.738732722522064'), 4468);


### PR DESCRIPTION
Формат передаваемого значения не оговорен в условии (значение может содержать более одной точки). Очень похоже на опечатку в тесте, либо не хватает условия в задании.