### PR TITLE
carbon-dating.test - fix nested tests in Mocha 

### DIFF
--- a/test/carbon-dating.test.js
+++ b/test/carbon-dating.test.js
@@ -46,7 +46,11 @@ describe('Carbon dating', () => {
   describe('functional requirements ', () => {
 
     describe('passes simpliest check and determines correct tests', () => {
-      const isLogCalculated = dateSample('1') === 22387 ? true : false;
+
+      let isLogCalculated = false;
+      try {
+        isLogCalculated = dateSample('1') === 22387;
+      } catch (e) { }
 
       if (isLogCalculated) {
         it.optional('basic examples', () => {

--- a/test/carbon-dating.test.js
+++ b/test/carbon-dating.test.js
@@ -45,7 +45,7 @@ describe('Carbon dating', () => {
 
   describe('functional requirements ', () => {
 
-    it.optional('passes simpliest check and determines correct tests', () => {
+    describe('passes simpliest check and determines correct tests', () => {
       const isLogCalculated = dateSample('1') === 22387 ? true : false;
 
       if (isLogCalculated) {


### PR DESCRIPTION
Looks like nested it() are not supported by Mocha
So here is probably a mistake - all tests under parent's
  it('passes simpliest check and determines correct tests', ...)
  do not run at all