### PR TITLE
Fix issue with recursive-depth test

### DIFF
--- a/test/recursive-depth.test.js
+++ b/test/recursive-depth.test.js
@@ -9,7 +9,7 @@ const DepthCalculator = require('../src/recursive-depth.js');
 const instance = new DepthCalculator();
 const calculateDepth = instance.calculateDepth.bind(instance);
 
-const createFlatArr = (length) => Array.from({length}, () => Math.floor(Math.random() * length));
+const createFlatArr = (length) => Array.from({ length }, () => Math.floor(Math.random() * length));
 
 describe('Recursive depth', () => {
     //Presence requirement
@@ -32,18 +32,18 @@ describe('Recursive depth', () => {
             assert.equal(calculateDepth([1, 2, 3, [1], 4, 5, [1]]), 2);
             assert.equal(calculateDepth([1, 2, 3, [8, [2]], 4, 5, []]), 3);
             assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, []]), 4);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, ['6575',['adas', ['dfg', [0]]]]]), 5);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], 4, 5, ['6575',['adas', ['dfg', [0]]]]]), 15);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575',['adas', ['dfg', [0]]]]]), 25);
-            assert.equal(calculateDepth([1, [8, [[]]], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]], []]]], []]]]]]]]], []]]], []]]]]]]]]], 2, 3, [8, [[[[[[[[[[[[[[]]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575',['adas', ['dfg', [0]]]]]), 31);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 5);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 15);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 25);
+            assert.equal(calculateDepth([1, [8, [[]]], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]], []]]], []]]]]]]]], []]]], []]]]]]]]]], 2, 3, [8, [[[[[[[[[[[[[[]]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 31);
         });
         it.optional('works recursively', () => {
             const spy1 = sinon.spy(instance, 'calculateDepth');
-            assert.equal(calculateDepth([1, 2, 3, 4, 5, [1, []]]), 3);
+            assert.equal(calculateDepth([1, 2, 3, 4, [1, 2, [1, 2, [[[]]]]], 5, [1, [[[[[[]]]]]]]]), 8);
             expect(spy1.callCount).to.be.greaterThan(1);
             spy1.restore();
             const spy2 = sinon.spy(instance, 'calculateDepth');
-            assert.equal(calculateDepth([[[[[]]]]]), 5);
+            assert.equal(calculateDepth([[[[[[[[[[]]]]]]]]]]), 10);
             expect(spy2.callCount).to.be.greaterThan(1);
             spy2.restore();
         });


### PR DESCRIPTION
Close #73 
Fix issue with Recursive Depth Calculator task test when function didn't work recursively due to the small nesting of the array.