### PR TITLE
fix: improve st-delete-digit test

### DIFF
--- a/test/st-delete-digit.test.js
+++ b/test/st-delete-digit.test.js
@@ -13,5 +13,6 @@ describe('st-delete-digit', () => {
     assert.strictEqual(deleteDigit(10), 1);
     assert.strictEqual(deleteDigit(222219), 22229);
     assert.strictEqual(deleteDigit(109), 19);
+    assert.strictEqual(deleteDigit(342), 42);
   });
 });


### PR DESCRIPTION
One more test case to ensure that solution doesn't simply remove the smallest digit.