### PR TITLE
docs: few fixes in "(ST) Minesweeper" and "(ST) Sum digits" descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ For example:
 
 For 100, the result should be 1 (1 + 0 + 0 = 1)  
 `getSumOfDigits(100)` => `1`
+
 For 91, the result should be 1 (9 + 1 = 10, 1 + 0 = 1)  
 `getSumOfDigits(91)` => `1`
 

--- a/README.md
+++ b/README.md
@@ -379,8 +379,6 @@ In the popular Minesweeper game you have a board with some mines and cells that 
 
 For example:
 
-For example:
-
 ```
 const matrix = [
  [true, false, false],


### PR DESCRIPTION
- Delete duplicated 'For example:' line in "(ST) Minesweeper" description
- Add linebreak in "(ST) Sum digits" 'For example:' part