### PR TITLE
Refactor: reorder Recursive depth calculator tests

### DIFF
--- a/test/recursive-depth.test.js
+++ b/test/recursive-depth.test.js
@@ -30,14 +30,14 @@ describe('Recursive depth', () => {
             }
         });
         it.optional('returns correct depth of nested arrays', () => {
-            assert.equal(calculateDepth([1, 2, 3, 4, 5, [1]]), 2);
-            assert.equal(calculateDepth([1, 2, 3, [1], 4, 5, [1]]), 2);
-            assert.equal(calculateDepth([1, 2, 3, [8, [2]], 4, 5, []]), 3);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, []]), 4);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 5);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 15);
-            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 25);
             assert.equal(calculateDepth([1, [8, [[]]], [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]], []]]], []]]]]]]]], []]]], []]]]]]]]]], 2, 3, [8, [[[[[[[[[[[[[[]]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 31);
+            assert.equal(calculateDepth([1, 2, 3, 4, 5, [1]]), 2);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 5);
+            assert.equal(calculateDepth([1, 2, 3, [8, [2]], 4, 5, []]), 3);
+            assert.equal(calculateDepth([1, 2, 3, [1], 4, 5, [1]]), 2);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], [8, [[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 25);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, []], 4, 5, []]), 4);
+            assert.equal(calculateDepth([1, [8, [[]]], 2, 3, [8, [[[[[[[[[[[[[]]]]]]]]]]]]]], 4, 5, ['6575', ['adas', ['dfg', [0]]]]]), 15);
         });
         it.optional('works recursively', () => {
             const spy1 = sinon.spy(instance, 'calculateDepth');


### PR DESCRIPTION
Reorder Recursive depth calculator tests to avoid case with common counter in class instance, which method wrongly handles that counter, and tests are passing because of test results have ascending order